### PR TITLE
fix limited precision of std::to_string when passing args to tetgen

### DIFF
--- a/VacuumMeshing/src/Utils/parseFlags.cpp
+++ b/VacuumMeshing/src/Utils/parseFlags.cpp
@@ -1,4 +1,7 @@
 #include "Utils/parseFlags.hpp"
+#include <sstream>
+#include <iomanip>
+#include <limits>
 
 typedef std::function<void(inputFlags &)> NoArgHandle;
 typedef std::function<void(inputFlags &, const std::string &)> OneArgHandle;
@@ -147,11 +150,17 @@ void inputFlags::setSwitches() {
   }
 
   if (maxTetVol.has_value()) {
-    tetSettings += "a" + std::to_string(maxTetVol.value());
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(std::numeric_limits<double>::digits10 + 1) << maxTetVol.value();
+    std::string mystring = ss.str();
+    tetSettings += "a" + ss.str();
   }
 
   if (maxTriArea.has_value()) {
-    triSettings += "a" + std::to_string(maxTriArea.value());
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(std::numeric_limits<double>::digits10 + 1) << maxTriArea.value();
+    std::string mystring = ss.str();
+    tetSettings += "a" + ss.str();
   }
 }
 


### PR DESCRIPTION
For small max tet volumes (anything less than 1e-6 pretty much), I was getting the error that it would be truncated to 0, causing tetgen to get caught in a loop of infinitely refining. I found this was due to the precision of `to_string` which has been replaced with a `stringstream`.

Should now work up to double precision (for tet volume and tri area).