### PR TITLE
Add check to avoid overwriting boundary IDs

### DIFF
--- a/VacuumMeshing/src/Utils/removeDupeNodes.cpp
+++ b/VacuumMeshing/src/Utils/removeDupeNodes.cpp
@@ -131,7 +131,17 @@ void combineMeshes(const double &tol, libMesh::Mesh &mesh_one,
     // Set boundary name!
   }
 
+  // provisionally take part_bdr_id as n_boundary_ids + 1
   int part_bdr_id = mesh_one.get_boundary_info().n_boundary_ids() + 1;
+  // check to see this ID is not already taken, if so we increment it by 
+  // one to avoid overwriting.
+  const auto & boundary_ids = mesh_one.boundary_info->get_boundary_ids();
+  for (auto id : boundary_ids){
+    if (part_bdr_id == id){
+      part_bdr_id ++;
+    }
+  }
+
   for (auto boundSide = surface_face_map.begin();
        boundSide != surface_face_map.end(); boundSide++) {
     // std::cout << boundSide->first << std::endl;


### PR DESCRIPTION
Hi @TheBEllis 

This small PR fixes a niche issue that occurs when the input mesh has boundary IDs such as the following: [0,1,3].
The old code would assign part_boundary as n_boundary_ids + 1, which would be boundary 3 (thus overwriting the pre-existing tag).

We add a loop over all boundary ids just to check this one is not already taken. If it is, then we assign the new part_boundary as ID+1 (giving a new boundary as 4 for the example above).